### PR TITLE
exclude zattrs when empty

### DIFF
--- a/lindi/LindiH5Store/LindiH5Store.py
+++ b/lindi/LindiH5Store/LindiH5Store.py
@@ -113,8 +113,8 @@ class LindiH5Store(Store):
         key_name = parts[-1]
         key_parent = "/".join(parts[:-1])
         if key_name == ".zattrs":
-            # Get the attributes of a group or dataset. We return this even if
-            # it is empty, but we exclude it when writing out the reference file
+            # Get the attributes of a group or dataset. If it is empty, we still
+            # return it, but we exclude it when writing out the reference file
             # system.
             return self._get_zattrs_bytes(key_parent)
         elif key_name == ".zgroup":

--- a/lindi/LindiH5Store/_util.py
+++ b/lindi/LindiH5Store/_util.py
@@ -5,7 +5,7 @@ import h5py
 
 def _get_h5_item(h5f: h5py.File, key: str):
     """Get an item from the h5 file, given its key."""
-    return h5f['/' + key]
+    return h5f.get('/' + key, None)
 
 
 def _read_bytes(file: IO, offset: int, count: int):

--- a/tests/test_with_real_data.py
+++ b/tests/test_with_real_data.py
@@ -298,5 +298,5 @@ def test_with_real_data():
         for k in top_level_keys:
             assert k in top_level_keys_2
 
-        root = zarr.open(store)
+        root = zarr.open(store, mode="r")
         _hdf5_visit_items(h5f, lambda key, item: _compare_item_2(item, root[key]))


### PR DESCRIPTION
Addresses #15 

With this, .zattrs is now excluded in the reference file system. However...

I felt it wasn't worth the overhead of determining whether attrs are empty in the `__contains__` function, especially since we are adding additional special attributes here and there. So, in the LindiH5Store, the file is still always present. But in the exported reference file system (where this matters more), it is excluded - because that's a much easier check. See notes in source code.

This PR also makes some fixes to the `__contains__` function and adds some asserts to the tests.