### PR TITLE
WIP: handle references in attrs and datasets

### DIFF
--- a/lindi/LindiClient/LindiAttributes.py
+++ b/lindi/LindiClient/LindiAttributes.py
@@ -1,5 +1,6 @@
 from typing import Union
 import zarr
+from .LindiReference import LindiReference
 
 
 class LindiAttributes:
@@ -10,6 +11,9 @@ class LindiAttributes:
         return self._object.attrs.get(key, default)
 
     def __getitem__(self, key):
+        val = self._object.attrs[key]
+        if isinstance(val, dict) and "_REFERENCE" in val:
+            return LindiReference(val["_REFERENCE"])
         return self._object.attrs[key]
 
     def __setitem__(self, key, value):

--- a/lindi/LindiClient/LindiAttributes.py
+++ b/lindi/LindiClient/LindiAttributes.py
@@ -8,7 +8,10 @@ class LindiAttributes:
         self._object = _object
 
     def get(self, key, default=None):
-        return self._object.attrs.get(key, default)
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
     def __getitem__(self, key):
         val = self._object.attrs[key]

--- a/lindi/LindiClient/LindiClient.py
+++ b/lindi/LindiClient/LindiClient.py
@@ -18,7 +18,11 @@ class LindiClient(LindiGroup):
         _zarr_group: zarr.Group,
     ) -> None:
         self._zarr_group = _zarr_group
-        super().__init__(_zarr_group=self._zarr_group)
+        super().__init__(_zarr_group=self._zarr_group, _client=self)
+
+    @property
+    def filename(self):
+        return ''
 
     @staticmethod
     def from_zarr_store(zarr_store: Union[Store, FSMap]) -> "LindiClient":
@@ -51,8 +55,21 @@ class LindiClient(LindiGroup):
 
     @staticmethod
     def from_reference_file_system(data: dict) -> "LindiClient":
-        fs = ReferenceFileSystem(data).get_mapper(root="/")
+        fs = ReferenceFileSystem(data).get_mapper(root="")
         return LindiClient.from_zarr_store(fs)
+
+    def get(self, key, default=None, getlink: bool = False):
+        try:
+            ret = self[key]
+        except KeyError:
+            ret = default
+        if getlink:
+            return ret
+        else:
+            if isinstance(ret, LindiReference):
+                return self[ret]
+            else:
+                return ret
 
     def __getitem__(self, key):  # type: ignore
         if isinstance(key, str):

--- a/lindi/LindiClient/LindiDataset.py
+++ b/lindi/LindiClient/LindiDataset.py
@@ -8,9 +8,10 @@ from .LindiReference import LindiReference
 
 
 class LindiDataset:
-    def __init__(self, *, _zarr_array: zarr.Array):
+    def __init__(self, *, _zarr_array: zarr.Array, _client):
         self._zarr_array = _zarr_array
         self._is_scalar = self._zarr_array.attrs.get("_SCALAR", False)
+        self._client = _client
 
         # See if we have the _COMPOUND_DTYPE attribute, which signifies that
         # this is a compound dtype
@@ -24,6 +25,14 @@ class LindiDataset:
             self._compound_dtype = None
 
         self._external_hdf5_clients: Dict[str, h5py.File] = {}
+
+    @property
+    def file(self):
+        return self._client
+
+    @property
+    def id(self):
+        return None
 
     @property
     def name(self):

--- a/lindi/LindiClient/LindiGroup.py
+++ b/lindi/LindiClient/LindiGroup.py
@@ -4,8 +4,17 @@ from .LindiDataset import LindiDataset
 
 
 class LindiGroup:
-    def __init__(self, *, _zarr_group: zarr.Group):
+    def __init__(self, *, _zarr_group: zarr.Group, _client):
         self._zarr_group = _zarr_group
+        self._client = _client
+
+    @property
+    def file(self):
+        return self._client
+
+    @property
+    def id(self):
+        return None
 
     @property
     def attrs(self):
@@ -33,9 +42,9 @@ class LindiGroup:
         if key in self._zarr_group.keys():
             x = self._zarr_group[key]
             if isinstance(x, zarr.Group):
-                return LindiGroup(_zarr_group=x)
+                return LindiGroup(_zarr_group=x, _client=self._client)
             elif isinstance(x, zarr.Array):
-                return LindiDataset(_zarr_array=x)
+                return LindiDataset(_zarr_array=x, _client=self._client)
             else:
                 raise Exception(f"Unknown type: {type(x)}")
         else:

--- a/lindi/LindiClient/LindiGroup.py
+++ b/lindi/LindiClient/LindiGroup.py
@@ -26,12 +26,10 @@ class LindiGroup:
             return default
 
     def __getitem__(self, key):
-        if isinstance(key, dict):
-            # might be a reference
-            if "_REFERENCE" in key:
-                return LindiReference(key['_REFERENCE'])
         if not isinstance(key, str):
-            raise Exception(f'Cannot use key "{key}" of type "{type(key)}" to index into a LindiGroup, at path "{self._zarr_group.name}"')
+            raise Exception(
+                f'Cannot use key "{key}" of type "{type(key)}" to index into a LindiGroup, at path "{self._zarr_group.name}"'
+            )
         if key in self._zarr_group.keys():
             x = self._zarr_group[key]
             if isinstance(x, zarr.Group):
@@ -46,21 +44,3 @@ class LindiGroup:
     def __iter__(self):
         for k in self.keys():
             yield k
-
-
-class LindiReference:
-    def __init__(self, obj: dict):
-        self._object_id = obj["object_id"]
-        self._path = obj["path"]
-        self._source = obj["source"]
-        self._source_object_id = obj["source_object_id"]
-
-    @property
-    def name(self):
-        return self._path
-
-    def __repr__(self):
-        return f"LindiReference({self._source}, {self._path})"
-
-    def __str__(self):
-        return f"LindiReference({self._source}, {self._path})"

--- a/lindi/LindiClient/LindiReference.py
+++ b/lindi/LindiClient/LindiReference.py
@@ -1,0 +1,16 @@
+class LindiReference:
+    def __init__(self, obj: dict):
+        self._object_id = obj["object_id"]
+        self._path = obj["path"]
+        self._source = obj["source"]
+        self._source_object_id = obj["source_object_id"]
+
+    @property
+    def name(self):
+        return self._path
+
+    def __repr__(self):
+        return f"LindiReference({self._source}, {self._path})"
+
+    def __str__(self):
+        return f"LindiReference({self._source}, {self._path})"

--- a/lindi/LindiClient/__init__.py
+++ b/lindi/LindiClient/__init__.py
@@ -2,4 +2,4 @@ from .LindiClient import LindiClient  # noqa: F401
 from .LindiGroup import LindiGroup  # noqa: F401
 from .LindiDataset import LindiDataset  # noqa: F401
 from .LindiAttributes import LindiAttributes  # noqa: F401
-from .LindiGroup import LindiReference  # noqa: F401
+from .LindiReference import LindiReference  # noqa: F401

--- a/lindi/LindiH5Store/_h5_filters_to_codecs.py
+++ b/lindi/LindiH5Store/_h5_filters_to_codecs.py
@@ -8,7 +8,7 @@ from numcodecs.abc import Codec
 # https://github.com/fsspec/kerchunk
 # Copyright (c) 2020 Intake
 # MIT License
-def _h5_filters_to_codecs(h5obj: h5py.Dataset) -> Union[List[Codec], None]:
+def _h5_filters_to_codecs_kerchunk(h5obj: h5py.Dataset) -> Union[List[Codec], None]:
     """Decode HDF5 filters to numcodecs filters."""
     if h5obj.scaleoffset:
         raise RuntimeError(

--- a/lindi/LindiH5Store/_h5_filters_to_codecs.py
+++ b/lindi/LindiH5Store/_h5_filters_to_codecs.py
@@ -8,7 +8,7 @@ from numcodecs.abc import Codec
 # https://github.com/fsspec/kerchunk
 # Copyright (c) 2020 Intake
 # MIT License
-def _h5_filters_to_codecs_kerchunk(h5obj: h5py.Dataset) -> Union[List[Codec], None]:
+def _h5_filters_to_codecs(h5obj: h5py.Dataset) -> Union[List[Codec], None]:
     """Decode HDF5 filters to numcodecs filters."""
     if h5obj.scaleoffset:
         raise RuntimeError(

--- a/lindi/LindiH5Store/_zarr_info_for_h5_dataset.py
+++ b/lindi/LindiH5Store/_zarr_info_for_h5_dataset.py
@@ -6,8 +6,8 @@ import numpy as np
 import numcodecs
 import h5py
 from numcodecs.abc import Codec
-from ._h5_filters_to_codecs import _h5_filters_to_codecs
 from ._h5_attr_to_zarr_attr import _h5_ref_to_zarr_attr
+from ._h5_filters_to_codecs import _h5_filters_to_codecs
 
 
 @dataclass


### PR DESCRIPTION
This PR builds on #19 

The goal here is to handle references in LindiH5Store and LindiClient such that the round-trip client handles refs in an equivalent way as the original h5py.

To illustrate, here are the tests that were added

```python
def test_reference_attributes():
    print("Testing reference attributes")
    with tempfile.TemporaryDirectory() as tmpdir:
        filename = f"{tmpdir}/test.h5"
        with h5py.File(filename, "w") as f:
            X_ds = f.create_dataset("X", data=[1, 2, 3])
            Y_ds = f.create_dataset("Y", data=[4, 5, 6])
            X_ds.attrs["ref"] = Y_ds.ref
        h5f = h5py.File(filename, "r")
        with LindiH5Store.from_file(filename, url=filename) as store:
            rfs = store.to_reference_file_system()
            client = LindiClient.from_reference_file_system(rfs)

            X1 = h5f["X"]
            assert isinstance(X1, h5py.Dataset)
            X2 = client["X"]
            assert isinstance(X2, LindiDataset)

            ref1 = X1.attrs["ref"]
            assert isinstance(ref1, h5py.Reference)
            ref2 = X2.attrs["ref"]
            assert isinstance(ref2, LindiReference)

            target1 = h5f[ref1]
            assert isinstance(target1, h5py.Dataset)
            target2 = client[ref2]
            assert isinstance(target2, LindiDataset)

            assert _check_equal(target1[:], target2[:])


def test_reference_in_compound_dtype():
    print("Testing reference in dataset with compound dtype")
    with tempfile.TemporaryDirectory() as tmpdir:
        filename = f"{tmpdir}/test.h5"
        with h5py.File(filename, "w") as f:
            compound_dtype = np.dtype([("x", "i4"), ("y", h5py.special_dtype(ref=h5py.Reference))])
            Y_ds = f.create_dataset("Y", data=[1, 2, 3])
            f.create_dataset("X", data=[(1, Y_ds.ref), (2, Y_ds.ref)], dtype=compound_dtype)
        h5f = h5py.File(filename, "r")
        with LindiH5Store.from_file(filename, url=filename) as store:
            rfs = store.to_reference_file_system()
            client = LindiClient.from_reference_file_system(rfs)

            X1 = h5f["X"]
            assert isinstance(X1, h5py.Dataset)
            X2 = client["X"]
            assert isinstance(X2, LindiDataset)

            assert _check_equal(X1["x"][:], X2["x"][:])
            ref1 = X1["y"][0]
            assert isinstance(ref1, h5py.Reference)
            ref2 = X2["y"][0]
            assert isinstance(ref2, LindiReference)

            target1 = h5f[ref1]
            assert isinstance(target1, h5py.Dataset)
            target2 = client[ref2]
            assert isinstance(target2, LindiDataset)

            assert _check_equal(target1[:], target2[:])
```