### PR TITLE
LindiReferenceFileSystemStore with DANDI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ LINDI features include:
 - A function for generating a reference file system .zarr.json file from a Zarr store. This is inspired by [kerchunk](https://github.com/fsspec/kerchunk).
 - An h5py-like interface for accessing these Zarr stores that can be used with [pynwb](https://pynwb.readthedocs.io/en/stable/).
 
-This project was inspired by [kerchunk](https://github.com/fsspec/kerchunk) and [hdmf-zarr](https://hdmf-zarr.readthedocs.io/en/latest/index.html) and depends on [zarr](https://zarr.readthedocs.io/en/stable/), [h5py](https://www.h5py.org/), [remfile](https://github.com/magland/remfile), [fsspec](https://filesystem-spec.readthedocs.io/en/latest/), and [numcodecs](https://numcodecs.readthedocs.io/en/stable/).
+This project was inspired by [kerchunk](https://github.com/fsspec/kerchunk) and [hdmf-zarr](https://hdmf-zarr.readthedocs.io/en/latest/index.html) and depends on [zarr](https://zarr.readthedocs.io/en/stable/), [h5py](https://www.h5py.org/), [remfile](https://github.com/magland/remfile) and [numcodecs](https://numcodecs.readthedocs.io/en/stable/).
 
 ## Installation
 

--- a/lindi/LindiH5pyFile/FileSegmentReader/DandiFileSegmentReader.py
+++ b/lindi/LindiH5pyFile/FileSegmentReader/DandiFileSegmentReader.py
@@ -1,0 +1,83 @@
+from typing import Union
+import os
+import time
+import requests
+import remfile
+from .FileSegmentReader import FileSegmentReader
+
+
+class DandiFileSegmentReader(FileSegmentReader):
+    """
+    A class that reads a segment of a file from a DANDI URL.
+
+    See the documentation for LindiReferenceFileSystemStore for more information
+    on why this class is needed.
+    """
+    def __init__(self, url: str):
+        # we intentionally do not call the super constructor
+        if not DandiFileSegmentReader.is_dandi_url(url):
+            raise Exception(f"{url} is not a dandi url")
+        self.url = url
+
+        # The DandiFile has a get_url() method which is in charge of resolving
+        # the URL, possibly using the DANDI API token, caching the result, and
+        # renewing periodically. remfile.File will accept such an object, and
+        # will call .get_url() as needed.
+        dandi_file = DandiFile(url)
+        self.remfile = remfile.File(dandi_file, verbose=True)
+
+    def read(self, offset: int, length: int):
+        self.remfile.seek(offset)
+        return self.remfile.read(length)
+
+    @staticmethod
+    def is_dandi_url(url: str):
+        if url.startswith('https://api.dandiarchive.org/api/'):
+            return True
+        if url.startswith('https://api-staging.dandiarchive.org/'):
+            return True
+        return False
+
+
+class DandiFile:
+    def __init__(self, url: str):
+        """
+        Create a new DandiFile which is in charge of resolving a DANDI URL
+        possibly using the DANDI API token, caching the result, and periodically
+        renewing the result.
+        """
+        self._url = url
+        self._resolved_url: Union[str, None] = None
+        self._resolved_url_timestamp: Union[float, None] = None
+
+    def get_url(self) -> str:
+        if self._resolved_url is not None and self._resolved_url_timestamp is not None:
+            if time.time() - self._resolved_url_timestamp < 120:
+                return self._resolved_url
+        resolve_with_dandi_api_key = None
+        if self._url.startswith('https://api.dandiarchive.org/api/'):
+            dandi_api_key = os.environ.get('DANDI_API_KEY', None)
+            if dandi_api_key is not None:
+                resolve_with_dandi_api_key = dandi_api_key
+        elif self._url.startswith('https://api-staging.dandiarchive.org/'):
+            dandi_api_key = os.environ.get('DANDI_STAGING_API_KEY', None)
+            if dandi_api_key is not None:
+                resolve_with_dandi_api_key = dandi_api_key
+        url0 = _resolve_dandi_url(url=self._url, dandi_api_key=resolve_with_dandi_api_key)
+        self._resolved_url = url0
+        self._resolved_url_timestamp = time.time()
+        return self._resolved_url
+
+# Example of URL resolution with DANDI API token:
+# https://api.dandiarchive.org/api/dandisets/000939/versions/0.240318.1555/assets/11f512ba-5bcf-4230-a8cb-dc8d36db38cb/download/
+# resolves to pre-signed S3 URL
+# https://dandiarchive.s3.amazonaws.com/blobs/a2b/94f/a2b94f91-6a75-43d8-b5db-21d89449f481?response-content-disposition=attachment%3B%20filename%3D%22sub-A3701_ses-191119_behavior%2Becephys.nwb%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAUBRWC5GAEKH3223E%2F20240321%2Fus-east-2%2Fs3%2Faws4_request&X-Amz-Date=20240321T122953Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=ed8cfd7a9d17a226cc18e20b5f32cfe9c467025c226f1abba236793e645dfcb0
+
+
+def _resolve_dandi_url(url: str, dandi_api_key: Union[str, None]) -> str:
+    headers = {}
+    if dandi_api_key is not None:
+        headers['Authorization'] = f'token {dandi_api_key}'
+    # do it synchronously here
+    resp = requests.head(url, allow_redirects=True, headers=headers)
+    return str(resp.url)

--- a/lindi/LindiH5pyFile/FileSegmentReader/FileSegmentReader.py
+++ b/lindi/LindiH5pyFile/FileSegmentReader/FileSegmentReader.py
@@ -1,0 +1,35 @@
+import remfile
+
+
+class FileSegmentReader:
+    """
+    A class that reads a segment of a file from a URL or a local path.
+    """
+    def __init__(self, url: str):
+        """
+        Create a new FileSegmentReader.
+
+        Parameters
+        ----------
+        url : str
+            The URL of the file to read, or a local path.
+        """
+        self.url = url
+        self.remfile = None
+        self.local_path = None
+        if url.startswith("http://") or url.startswith("https://"):
+            # remfile does not need to be closed
+            self.remfile = remfile.File(url)
+        else:
+            self.local_path = url
+
+    def read(self, offset: int, length: int):
+        if self.remfile is not None:
+            self.remfile.seek(offset)
+            return self.remfile.read(length)
+        elif self.local_path is not None:
+            with open(self.local_path, "rb") as f:
+                f.seek(offset)
+                return f.read(length)
+        else:
+            raise Exception("Unexpected: no remfile or local_path")

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -1,0 +1,140 @@
+from typing import Literal, Dict
+import base64
+from zarr.storage import Store as ZarrStore
+from .FileSegmentReader.FileSegmentReader import FileSegmentReader
+from .FileSegmentReader.DandiFileSegmentReader import DandiFileSegmentReader
+
+
+class LindiReferenceFileSystemStore(ZarrStore):
+    """
+    A Zarr store that reads data from a reference file system.
+
+    The reference file system is based on the ReferenceFileSystem of fsspec, but
+    this is a custom implementation that serves some LINDI-specific needs. In
+    particular, it handles reading data from DANDI URLs, even when the file is
+    part of an embargoed dataset. This requires some special handling as the
+    DANDI API URL must be exchanged for a pre-signed S3 bucket URL by
+    authenticating with a DANDI API token. This presigned URL expires have a
+    period of time, so this Zarr store handles the renewal of the presigned URL.
+    It also does the exchange once the first time and caches the redirected URL
+    for a period so that the redirect doesn't need to be done every time a
+    segment of a file is read.
+
+    To read from a file in an embargoed DANDI dataset, you will need to set the
+    DANDI_API_KEY environment variable to your DANDI API token. Or, if this is
+    and Dandiset in the staging site, you will need to set the
+    DANDI_STAGING_API_KEY.
+
+    Following the fsspec convention, the reference file system is specified as a
+    dictionary with a "refs" key. The value of "refs" is a dictionary where the
+    keys are the names of the files and the values are either strings or lists.
+    If the value is a string, it is assumed to be the data of the file, which
+    may be base64 encoded (see below). If the value is a list, it is assumed to
+    have three elements: the URL of the file (or path of a local file), the byte
+    offset of the data within the file, and the byte length of the data.
+
+    If the value for a file is a string, it may be prefixed with "base64:". If
+    it is, the string is assumed to be base64 encoded and is decoded before
+    being returned. Otherwise, the string is utf-8 encoded and returned as is.
+    Note that a file that actually begins with "base64:" should be represented
+    by a base64 encoded string, to avoid ambiguity.
+    """
+    def __init__(self, rfs: dict, mode: Literal["r"] = "r"):
+        """
+        Create a LindiReferenceFileSystemStore.
+
+        Parameters
+        ----------
+        rfs : dict
+            The reference file system (see class docstring for details).
+        mode : str
+            The mode to open the store in. Only "r" is supported at this time.
+        """
+        if "refs" not in rfs:
+            raise Exception("rfs must contain a 'refs' key")
+
+        # validate rfs['refs']
+        for k, v in rfs["refs"].items():
+            if isinstance(v, str):
+                pass
+            elif isinstance(v, list):
+                if len(v) != 3:
+                    raise Exception(f"Problem with {k}: list must have 3 elements")
+                if not isinstance(v[0], str):
+                    raise Exception(f"Problem with {k}: first element must be a string")
+                if not isinstance(v[1], int):
+                    raise Exception(f"Problem with {k}: second element must be an int")
+                if not isinstance(v[2], int):
+                    raise Exception(f"Problem with {k}: third element must be an int")
+            else:
+                raise Exception(f"Problem with {k}: value must be a string or a list")
+
+        self.rfs = rfs
+        self.mode = mode
+
+    # These methods are overridden from MutableMapping
+    def __getitem__(self, key: str):
+        if key not in self.rfs["refs"]:
+            raise KeyError(key)
+        x = self.rfs["refs"][key]
+        if isinstance(x, str):
+            if x.startswith("base64:"):
+                return base64.b64decode(x[len("base64:"):])
+            else:
+                return x.encode("utf-8")
+        elif isinstance(x, list):
+            if len(x) != 3:
+                raise Exception("list must have 3 elements")
+            url = x[0]
+            offset = x[1]
+            length = x[2]
+            val = _read_bytes_from_url(url, offset, length)
+            return val
+        else:
+            raise Exception(f"Problem with {key}: value must be a string or a list")
+
+    def __setitem__(self, key: str, value):
+        raise Exception("Setting items is not allowed")
+
+    def __delitem__(self, key: str):
+        raise Exception("Deleting items is not allowed")
+
+    def __iter__(self):
+        return iter(self.rfs["refs"])
+
+    def __len__(self):
+        return len(self.rfs["refs"])
+
+    # These methods are overridden from BaseStore
+    def is_readable(self):
+        return self.mode in ["r"]
+
+    def is_writeable(self):
+        return False
+
+    def is_listable(self):
+        return True
+
+    def is_erasable(self):
+        return False
+
+
+# Keep a global cache of file segment readers that apply to all instances of
+# LindiReferenceFileSystemStore. The key is the URL of the file.
+_file_segment_readers: Dict[str, FileSegmentReader] = {}
+
+
+def _read_bytes_from_url(url: str, offset: int, length: int):
+    """
+    Read a range of bytes from a URL.
+    """
+    if url not in _file_segment_readers:
+        if DandiFileSegmentReader.is_dandi_url(url):
+            # This is a DANDI URL, so it needs to be handled specially
+            # see the docstring for DandiFileSegmentReader for details
+            file_segment_reader = DandiFileSegmentReader(url)
+        else:
+            # This is a non-DANDI URL or local file path
+            file_segment_reader = FileSegmentReader(url)
+        _file_segment_readers[url] = file_segment_reader
+    return _file_segment_readers[url].read(offset, length)

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -25,7 +25,8 @@ class LindiReferenceFileSystemStore(ZarrStore):
     a Dandiset on the staging server, you will need to set the
     DANDI_STAGING_API_KEY.
 
-    Following the fsspec convention, the reference file system is specified as a
+    Following the fsspec convention (https://fsspec.github.io/kerchunk/spec.html),
+    the reference file system is specified as a
     dictionary with a "refs" key. The value of "refs" is a dictionary where the
     keys are the names of the files and the values are either strings or lists.
     If the value is a string, it is assumed to be the data of the file, which

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -14,7 +14,7 @@ class LindiReferenceFileSystemStore(ZarrStore):
     particular, it handles reading data from DANDI URLs, even when the file is
     part of an embargoed dataset. This requires some special handling as the
     DANDI API URL must be exchanged for a pre-signed S3 bucket URL by
-    authenticating with a DANDI API token. This presigned URL expires have a
+    authenticating with a DANDI API token. This presigned URL expires after a
     period of time, so this Zarr store handles the renewal of the presigned URL.
     It also does the exchange once the first time and caches the redirected URL
     for a period so that the redirect doesn't need to be done every time a

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -22,7 +22,7 @@ class LindiReferenceFileSystemStore(ZarrStore):
 
     To read from a file in an embargoed DANDI dataset, you will need to set the
     DANDI_API_KEY environment variable to your DANDI API token. Or, if this is
-    and Dandiset in the staging site, you will need to set the
+    a Dandiset on the staging server, you will need to set the
     DANDI_STAGING_API_KEY.
 
     Following the fsspec convention, the reference file system is specified as a

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -92,6 +92,8 @@ class LindiReferenceFileSystemStore(ZarrStore):
             val = _read_bytes_from_url(url, offset, length)
             return val
         else:
+            # should not happen given checks in __init__, but self.rfs is mutable
+            # and contains mutable lists
             raise Exception(f"Problem with {key}: value must be a string or a list")
 
     def __setitem__(self, key: str, value):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ numcodecs = "^0.12.1"
 zarr = "^2.16.1"
 h5py = "^3.10.0"
 remfile = "^0.1.9"
-fsspec = "^2023.12.2"
-aiohttp = "^3.9.3"
 requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Here's the docstring of the new LindiReferenceFileSystemStore class. This explains the purpose of this PR

LindiReferenceFileSystemStore is a Zarr store that reads data from a reference file system with special handling of some LINDI/DANDI-specific needs.

    The reference file system is based on the ReferenceFileSystem of fsspec, but
    this is a custom implementation that serves some LINDI-specific needs. In
    particular, it handles reading data from DANDI URLs, even when the file is
    part of an embargoed dataset. This requires some special handling as the
    DANDI API URL must be exchanged for a pre-signed S3 bucket URL by
    authenticating with a DANDI API token. This presigned URL expires have a
    period of time, so this Zarr store handles the renewal of the presigned URL.
    It also does the exchange once the first time and caches the redirected URL
    for a period so that the redirect doesn't need to be done every time a
    segment of a file is read.

    To read from a file in an embargoed DANDI dataset, you will need to set the
    DANDI_API_KEY environment variable to your DANDI API token. Or, if this is
    and Dandiset in the staging site, you will need to set the
    DANDI_STAGING_API_KEY.

    Following the fsspec convention, the reference file system is specified as a
    dictionary with a "refs" key. The value of "refs" is a dictionary where the
    keys are the names of the files and the values are either strings or lists.
    If the value is a string, it is assumed to be the data of the file, which
    may be base64 encoded (see below). If the value is a list, it is assumed to
    have three elements: the URL of the file (or path of a local file), the byte
    offset of the data within the file, and the byte length of the data.

    If the value for a file is a string, it may be prefixed with "base64:". If
    it is, the string is assumed to be base64 encoded and is decoded before
    being returned. Otherwise, the string is utf-8 encoded and returned as is.
    Note that a file that actually begins with "base64:" should be represented
    by a base64 encoded string, to avoid ambiguity.