### PR TITLE
Add metadata to dtype when kind is 'O'

### DIFF
--- a/lindi/LindiH5pyFile/LindiH5pyDataset.py
+++ b/lindi/LindiH5pyFile/LindiH5pyDataset.py
@@ -103,7 +103,26 @@ class LindiH5pyDataset(h5py.Dataset):
                 #             return StrDataset(h5obj, None)
                 #     return h5obj
                 # We cannot have a dtype with kind 'O' and no metadata
-                ret = np.dtype(str(ret), metadata={})
+                # There is also this section in pynwb validator.py
+                # if isinstance(received, np.dtype):
+                #     if received.char == 'O':
+                #         if 'vlen' in received.metadata:
+                #             received = received.metadata['vlen']
+                #         else:
+                #             raise ValueError("Unrecognized type: '%s'" % received)
+                #         received = 'utf' if received is str else 'ascii'
+                #     elif received.char == 'U':
+                #         received = 'utf'
+                #     elif received.char == 'S':
+                #         received = 'ascii'
+                #     else:
+                #         received = received.name
+                # ------------------------------------------
+                # I don't know how to figure out when vlen should be str or bytes
+                # but validate seems to work only when I put in vlen = bytes
+                #
+                vlen = bytes
+                ret = np.dtype(str(ret), metadata={'vlen': vlen})
         return ret
 
     @property


### PR DESCRIPTION
In order to get pynwb validation to pass I needed to make the tweak of this PR. It seems that h5py uses a vlen field in metadata for a numpy dtype, and pynwb inspects that. I don't understand exactly what this is about. But when I set it to bytes in this case, the validation passes.

Here's a test validation script where things are passing with this PR

```python

import pynwb
from pynwb import CORE_NAMESPACE
from pynwb.validate import ValidatorMap
import h5py
import remfile
import lindi


def test_validate(io: pynwb.NWBHDF5IO):
    namespace = CORE_NAMESPACE
    validator = ValidatorMap(namespace=io.manager.namespace_catalog.get_namespace(name=namespace))
    builder = io.read_builder()
    validation_errors = validator.validate(builder=builder)
    if len(validation_errors) == 0:
        print('Validation passed!')
    else:
        print('Validation failed!')
        for ve in validation_errors:
            print(ve)


if __name__ == "__main__":
    # https://neurosift.app/?p=/nwb&dandisetId=000409&dandisetVersion=draft&url=https://api.dandiarchive.org/api/assets/c04f6b30-82bf-40e1-9210-34f0bcd8be24/download/

    print('')
    print('Validating with HDF5 URL...')
    h5_url = 'https://api.dandiarchive.org/api/assets/c04f6b30-82bf-40e1-9210-34f0bcd8be24/download/'
    remf = remfile.File(h5_url)
    h5f = h5py.File(remf, mode='r')
    with pynwb.NWBHDF5IO(file=h5f, mode='r', load_namespaces=True) as io:
        test_validate(io)

    print('')
    print('Validating with LINDI URL...')
    lindi_url = 'https://lindi.neurosift.org/dandi/dandisets/000409/assets/c04f6b30-82bf-40e1-9210-34f0bcd8be24/zarr.json'
    ff = lindi.LindiH5pyFile.from_reference_file_system(lindi_url)
    with pynwb.NWBHDF5IO(file=ff, mode='r', load_namespaces=True) as io:
        test_validate(io)
```