### PR TITLE
implement templates for reference file system

### DIFF
--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -578,7 +578,8 @@ class LindiH5ZarrStore(Store):
         # Process the groups recursively starting with the root group
         _process_group("", self._h5f)
 
-        LindiReferenceFileSystemStore.replace_meta_file_contents_with_dicts(ret)
+        LindiReferenceFileSystemStore.replace_meta_file_contents_with_dicts_in_rfs(ret)
+        LindiReferenceFileSystemStore.use_templates_in_rfs(ret)
         return ret
 
 

--- a/lindi/LindiH5pyFile/LindiH5pyFile.py
+++ b/lindi/LindiH5pyFile/LindiH5pyFile.py
@@ -135,7 +135,8 @@ class LindiH5pyFile(h5py.File):
             raise Exception(f"Unexpected type for zarr store: {type(self._zarr_store)}")
         rfs = self._zarr_store.rfs
         rfs_copy = json.loads(json.dumps(rfs))
-        LindiReferenceFileSystemStore.replace_meta_file_contents_with_dicts(rfs_copy)
+        LindiReferenceFileSystemStore.replace_meta_file_contents_with_dicts_in_rfs(rfs_copy)
+        LindiReferenceFileSystemStore.use_templates_in_rfs(rfs_copy)
         return rfs_copy
 
     @property

--- a/lindi/LindiStagingStore/LindiStagingStore.py
+++ b/lindi/LindiStagingStore/LindiStagingStore.py
@@ -128,7 +128,7 @@ class LindiStagingStore(ZarrStore):
             self.consolidate_chunks()
         rfs = self._base_store.rfs
         rfs = json.loads(json.dumps(rfs))  # deep copy
-        LindiReferenceFileSystemStore.replace_meta_file_contents_with_dicts(rfs)
+        LindiReferenceFileSystemStore.replace_meta_file_contents_with_dicts_in_rfs(rfs)
         blob_mapping = _upload_directory_of_blobs(self._staging_area.directory, on_upload_blob=on_upload_blob)
         for k, v in rfs['refs'].items():
             if isinstance(v, list) and len(v) == 3:
@@ -140,6 +140,7 @@ class LindiStagingStore(ZarrStore):
                     rfs['refs'][k][0] = url2
         with tempfile.TemporaryDirectory() as tmpdir:
             rfs_fname = f"{tmpdir}/rfs.lindi.json"
+            LindiReferenceFileSystemStore.use_templates_in_rfs(rfs)
             _write_rfs_to_file(rfs=rfs, output_file_name=rfs_fname)
             return on_upload_main(rfs_fname)
 


### PR DESCRIPTION
Implements the use of templates in reference file system as in fsspec, but does not support the full jinja2 templating.

For example,
```
{
    "templates": {"u1": "https://some/url", "u2": "https://some/other/url"},
    "refs": {
        ... "/some/key/0": [
            "{{u1}}" 0, 100
        ],
        ...
    }
}
```

In this case, the "{{u1}}" will be replaced with the value of the "u1" template string.