### PR TITLE
Allow LindiH5pyFile.from_hdf5_file to accept remote URL for local file

### DIFF
--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -443,7 +443,7 @@ class LindiH5ZarrStore(Store):
                 if self._url is not None:
                     self._external_array_links[parent_key] = {
                         "link_type": "hdf5_dataset",
-                        "url": self._url,  # url is not going to be null based on the check in __init__
+                        "url": self._url,
                         "name": parent_key,
                     }
                 else:

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
@@ -11,6 +11,7 @@ class LindiH5ZarrStoreOpts:
         num_dataset_chunks_threshold (Union[int, None]): For each dataset in the
         HDF5 file, if the number of chunks is greater than this threshold, then
         the dataset will be represented as an external array link. If None, then
-        the threshold is not used. Default is 1000.
+        no datasets will be represented as external array links (equivalent to a
+        threshold of 0). Default is 1000.
     """
     num_dataset_chunks_threshold: Union[int, None] = 1000

--- a/lindi/LindiH5pyFile/LindiH5pyFile.py
+++ b/lindi/LindiH5pyFile/LindiH5pyFile.py
@@ -58,7 +58,14 @@ class LindiH5pyFile(h5py.File):
         return LindiH5pyFile.from_reference_file_system(url_or_path, mode=mode, staging_area=staging_area, local_cache=local_cache, local_file_path=local_file_path)
 
     @staticmethod
-    def from_hdf5_file(url_or_path: str, *, mode: LindiFileMode = "r", local_cache: Union[LocalCache, None] = None, zarr_store_opts: Union[LindiH5ZarrStoreOpts, None] = None):
+    def from_hdf5_file(
+        url_or_path: str,
+        *,
+        mode: LindiFileMode = "r",
+        local_cache: Union[LocalCache, None] = None,
+        zarr_store_opts: Union[LindiH5ZarrStoreOpts, None] = None,
+        url: Union[str, None] = None
+    ):
         """
         Create a LindiH5pyFile from a URL or path to an HDF5 file.
 
@@ -73,11 +80,18 @@ class LindiH5pyFile(h5py.File):
             The local cache to use for caching data chunks, by default None.
         zarr_store_opts : Union[LindiH5ZarrStoreOpts, None], optional
             The options to use for the zarr store, by default None.
+        url : str or None
+            If url_or_path is a local file name, then this can
+            optionally be set to the URL of the remote file to be used when
+            creating references. If None, and the url_or_path is a
+            local file name, then you will need to set
+            zarr_store_opts.num_dataset_chunks_threshold to None, and you will not be able
+            to use the to_reference_file_system method.
         """
         from ..LindiH5ZarrStore.LindiH5ZarrStore import LindiH5ZarrStore  # avoid circular import
         if mode != "r":
             raise Exception("Opening hdf5 file in write mode is not supported")
-        zarr_store = LindiH5ZarrStore.from_file(url_or_path, local_cache=local_cache, opts=zarr_store_opts, url=url_or_path)
+        zarr_store = LindiH5ZarrStore.from_file(url_or_path, local_cache=local_cache, opts=zarr_store_opts, url=url)
         return LindiH5pyFile.from_zarr_store(
             zarr_store=zarr_store,
             mode=mode,


### PR DESCRIPTION
I would like to download a remote HDF5 file and create a lindi file with references to the remote location using the downloaded local HDF5 file. I think creating such a lindi file using a remote HDF5 file would take longer than downloading the file and creating such a lindi file using the downloaded local HDF5 file, but I am not sure.

`LindiH5ZarrStore.from_file` lets you create a store using a local file with references to the remote location: https://github.com/NeurodataWithoutBorders/lindi/blob/1fc62ef070b9cb545704f69a71dad26acbdb6f7f/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py#L69

`LindiH5pyFile.from_hdf5_file` calls `LindiH5ZarrStore.from_file` but does not let the user set the remote location to a location different from the file location: https://github.com/NeurodataWithoutBorders/lindi/blob/1fc62ef070b9cb545704f69a71dad26acbdb6f7f/lindi/LindiH5pyFile/LindiH5pyFile.py#L61

This PR exposes the `url` keyword argument in `LindiH5ZarrStore.from_file` to `LindiH5pyFile.from_hdf5_file` to allow those two locations to be different. The docstring is copied from `LindiH5ZarrStore.from_file` and modified. 

@magland please confirm that the last sentence of the docstring for `url` is still valid. 