### PR TITLE
Use chunk_iter when adding chunk refs

### DIFF
--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -601,8 +601,6 @@ class LindiH5ZarrStore(Store):
             raise Exception("You must specify a url to create a reference file system")
         ret = {"refs": {}, "version": 1}
 
-        # TODO: use templates to decrease the size of the JSON
-
         def _add_ref(key: str, content: Union[bytes, None]):
             if content is None:
                 raise Exception(f"Unable to get content for key {key}")
@@ -629,7 +627,7 @@ class LindiH5ZarrStore(Store):
         def _add_ref_chunk(key: str, data: Tuple[str, int, int]):
             assert data[1] is not None
             assert data[2] is not None
-            ret["refs"][key] = list(data)  # TODO make downstream accept tuple
+            ret["refs"][key] = list(data)  # downstream expects a list like on read from a JSON file
 
         def _process_group(key, item: h5py.Group):
             if isinstance(item, h5py.Group):

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -492,8 +492,13 @@ class LindiH5ZarrStore(Store):
                             )
                     assert chunk_index == _get_chunk_index(h5_item, chunk_coords)
 
-                    byte_offset = chunk_info[chunk_index].byte_offset
-                    byte_count = chunk_info[chunk_index].size
+                    # use chunk_info if available on this system because it is more efficient,
+                    # otherwise use the slower _get_chunk_byte_range
+                    if chunk_info is not None:
+                        byte_offset = chunk_info[chunk_index].byte_offset
+                        byte_count = chunk_info[chunk_index].size
+                    else:
+                        byte_offset, byte_count = _get_chunk_byte_range(h5_item, chunk_coords)
                 except Exception as e:
                     raise Exception(
                         f"Error getting byte range for chunk {key_parent}/{key_name}. Shape: {h5_item.shape}, Chunks: {h5_item.chunks}, Chunk coords: {chunk_coords}: {e}"

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -406,21 +406,17 @@ class LindiH5ZarrStore(Store):
                 raise Exception(
                     f"Chunk coordinates {chunk_coords} out of range for dataset {key_parent} with dtype {h5_item.dtype}"
                 )
-
         if h5_item.chunks is not None:
             # Get the byte range in the file for the chunk.
             try:
-                # Get the chunk coords from the file name
                 byte_offset, byte_count = _get_chunk_byte_range(h5_item, chunk_coords)
             except Exception as e:
                 raise Exception(
                     f"Error getting byte range for chunk {key_parent}/{key_name}. Shape: {h5_item.shape}, Chunks: {h5_item.chunks}, Chunk coords: {chunk_coords}: {e}"
                 )
-
         else:
             # In this case (contiguous dataset), we need to check that the chunk
             # coordinates are (0, 0, 0, ...)
-            chunk_coords = tuple(int(x) for x in key_name.split("."))
             if chunk_coords != (0,) * h5_item.ndim:
                 raise Exception(
                     f"Chunk coordinates {chunk_coords} are not (0, 0, 0, ...) for contiguous dataset {key_parent} with dtype {h5_item.dtype} and shape {h5_item.shape}"
@@ -502,7 +498,6 @@ class LindiH5ZarrStore(Store):
 
                 # In this case we reference a chunk of data in a separate file
                 add_ref_chunk(f"{key_parent}/{key_name}", (self._url, byte_offset, byte_count))
-
         else:
             # In this case (contiguous dataset), we need to check that the chunk
             # coordinates are (0, 0, 0, ...)

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -8,6 +8,7 @@ import h5py
 from tqdm import tqdm
 from ._util import (
     _read_bytes,
+    _get_max_num_chunks,
     _apply_to_all_chunk_info,
     _get_chunk_byte_range,
     _get_byte_range_for_contiguous_dataset,
@@ -450,8 +451,7 @@ class LindiH5ZarrStore(Store):
         if h5_item.chunks is not None:
             # Set up progress bar for manual updates because h5py chunk_iter used in _apply_to_all_chunk_info
             # does not provide a way to hook in a progress bar
-            dsid = h5_item.id
-            num_chunks = dsid.get_num_chunks()  # NOTE: this is very slow if dataset is remote and has many chunks
+            num_chunks = _get_max_num_chunks(h5_item)  # NOTE: unallocated chunks are counted
             pbar = tqdm(
                 total=num_chunks,
                 desc=f"Writing chunk info for {key_parent}",

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -451,6 +451,8 @@ class LindiH5ZarrStore(Store):
         if h5_item.chunks is not None:
             # Set up progress bar for manual updates because h5py chunk_iter used in _apply_to_all_chunk_info
             # does not provide a way to hook in a progress bar
+            # We use max number of chunks instead of actual number of chunks because get_num_chunks is slow
+            # for remote datasets.
             num_chunks = _get_max_num_chunks(h5_item)  # NOTE: unallocated chunks are counted
             pbar = tqdm(
                 total=num_chunks,

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -327,7 +327,7 @@ class LindiH5ZarrStore(Store):
         if self._file is None:
             raise Exception("Store is closed")
         byte_offset, byte_count, inline_data = self._get_chunk_file_bytes_data(
-            key_parent, [key_name]
+            key_parent, key_name
         )
         if inline_data is not None:
             return inline_data
@@ -354,11 +354,7 @@ class LindiH5ZarrStore(Store):
                 )
             return buf
 
-    def _get_chunk_file_bytes_data(
-        self,
-        key_parent: str,
-        key_name: str
-    ):
+    def _get_chunk_file_bytes_data(self, key_parent: str, key_name: str):
         if self._h5f is None:
             raise Exception("Store is closed")
         h5_item = self._h5f.get('/' + key_parent, None)

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -460,6 +460,7 @@ class LindiH5ZarrStore(Store):
             )
 
             chunk_size = h5_item.chunks
+
             def store_chunk_info(chunk_info):
                 # Get the byte range in the file for each chunk.
                 chunk_offset: Tuple[int, ...] = chunk_info.chunk_offset
@@ -620,7 +621,6 @@ class LindiH5ZarrStore(Store):
             zarray_bytes = self.get(f"{key}/.zarray")
             assert zarray_bytes is not None
             _add_ref(f"{key}/.zarray", zarray_bytes)
-            zarray_dict = json.loads(zarray_bytes.decode("utf-8"))
 
             if external_array_link is None:
                 # Only add chunk references for datasets without an external array link

--- a/lindi/LindiH5ZarrStore/_util.py
+++ b/lindi/LindiH5ZarrStore/_util.py
@@ -81,7 +81,7 @@ def _get_chunk_byte_range(h5_dataset: h5py.Dataset, chunk_coords: tuple) -> tupl
 def _get_chunk_byte_range_for_chunk_index(h5_dataset: h5py.Dataset, chunk_index: int) -> tuple:
     """Get the byte range in the file for a chunk of an h5py dataset.
 
-    This involves some low-level functions from the h5py library. Use _get_all_chunk_info instead of
+    This involves some low-level functions from the h5py library. Use _apply_to_all_chunk_info instead of
     calling this repeatedly for many chunks of the same dataset.
     """
     # got hints from kerchunk source code

--- a/lindi/LindiH5ZarrStore/_util.py
+++ b/lindi/LindiH5ZarrStore/_util.py
@@ -54,6 +54,7 @@ def _get_chunk_index(h5_dataset: h5py.Dataset, chunk_coords: tuple) -> int:
         chunk_index += int(chunk_coords[i] * np.prod(chunk_coords_shape[i + 1:]))
     return chunk_index
 
+
 def _get_chunk_byte_range(h5_dataset: h5py.Dataset, chunk_coords: tuple) -> tuple:
     """Get the byte range in the file for a chunk of an h5py dataset.
 

--- a/lindi/LindiH5ZarrStore/_util.py
+++ b/lindi/LindiH5ZarrStore/_util.py
@@ -44,7 +44,7 @@ def _apply_to_all_chunk_info(h5_dataset: h5py.Dataset, callback: Callable):
         dsid.chunk_iter(callback)
     except AttributeError:
         # chunk_iter is not available
-        num_chunks = _get_max_num_chunks(dsid)
+        num_chunks = dsid.get_num_chunks()  # NOTE: this can be slow for remote datasets with many chunks
         if num_chunks > 100:
             warnings.warn(
                 f"Dataset {h5_dataset.name} has {num_chunks} chunks. Using get_chunk_info is slow. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ numcodecs = "^0.12.1"
 zarr = "^2.16.1"
 h5py = "^3.10.0"
 requests = "^2.31.0"
+tqdm = "^4.66.4"
 
 [tool.poetry.group.dev.dependencies]
 pynwb = "^2.6.0"


### PR DESCRIPTION
Fix #67.

I added `lindi.LindiH5ZarrStore._util._get_all_chunk_info`. 

`LindiH5ZarrStore._get_chunk_file_bytes_data` was being called in two places:
1. in `to_reference_file_system.process_dataset` in a loop over all chunks to get the chunk info for each chunk to add to the refs dict
2. by `_get_chunk_file_bytes` which is called by `__getitem__` for a single key

Because the new `chunk_iter` method returns the chunk info for all chunks and takes 1-5 seconds, it is best to use that in use case 1 above. The old `get_chunk_info` method takes about 0.2 seconds. It is best to use that for use case 2 above when a user wants to access a single key. 

TODO: if the user wants to access more than ~10 keys for a given dataset, e.g., they are requesting a large slice, then probably it would be best to use the `chunk_iter` method and cache the chunk info in `LindiH5ZarrStore`. Alternatively, we could just always run `chunk_iter` and cache the chunk info.

I tried putting a bunch of if/else branches in `LindiH5ZarrStore._get_chunk_file_bytes_data` to handle the two use cases above, but it got messy and complex. So I just created a new function `_add_chunk_info_to_refs` for use case 1 which has some of the same code as `_get_chunk_file_bytes_data`. It needs to be refactored.

This also adds `tqdm` as a dependency for showing a progress bar when iterating through many chunks. I think that is useful overall, but we could move that to an optional dependency if we think it is not so important.

@magland before I continue, can you take a look at this and let me know if I am understanding the code correctly and if the approach looks good?

TODO:
- [x] refactor redundant code
- [x] remove unnecessary chunk coordinate calculating code
- [ ] add tests, especially with HDF5 < 1.12.3 and >= 1.12.3
