### PR TITLE
LocalCache: limit allowed blob size

### DIFF
--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -345,12 +345,15 @@ class LindiH5ZarrStore(Store):
             buf = _read_bytes(self._file, byte_offset, byte_count)
             if self._local_cache is not None:
                 assert self._url is not None, "Unexpected: url is None but local_cache is not None"
-                self._local_cache.put_remote_chunk(
-                    url=self._url,
-                    offset=byte_offset,
-                    size=byte_count,
-                    data=buf
-                )
+                if byte_count < 1000 * 1000 * 900:
+                    self._local_cache.put_remote_chunk(
+                        url=self._url,
+                        offset=byte_offset,
+                        size=byte_count,
+                        data=buf
+                    )
+                else:
+                    print(f"Warning: Not storing chunk of size {byte_count} in local cache in LindiH5ZarrStore (key: {key_parent}/{key_name})")
             return buf
 
     def _get_chunk_file_bytes_data(self, key_parent: str, key_name: str):

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -4,7 +4,7 @@ import base64
 import requests
 from zarr.storage import Store as ZarrStore
 
-from ..LocalCache.LocalCache import LocalCache
+from ..LocalCache.LocalCache import ChunkTooLargeError, LocalCache
 
 
 class LindiReferenceFileSystemStore(ZarrStore):
@@ -141,10 +141,10 @@ class LindiReferenceFileSystemStore(ZarrStore):
                     return x
             val = _read_bytes_from_url_or_path(url, offset, length)
             if self.local_cache is not None:
-                if length < 1000 * 1000 * 900:
+                try:
                     self.local_cache.put_remote_chunk(url=url, offset=offset, size=length, data=val)
-                else:
-                    print(f'Warning: not caching chunk of size {length} om LindiReferenceFileSystemStore (key: {key})')
+                except ChunkTooLargeError:
+                    print(f'Warning: unable to cache chunk of size {length} on LocalCache (key: {key})')
             return val
         else:
             # should not happen given checks in __init__, but self.rfs is mutable

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -141,7 +141,10 @@ class LindiReferenceFileSystemStore(ZarrStore):
                     return x
             val = _read_bytes_from_url_or_path(url, offset, length)
             if self.local_cache is not None:
-                self.local_cache.put_remote_chunk(url=url, offset=offset, size=length, data=val)
+                if length < 1000 * 1000 * 900:
+                    self.local_cache.put_remote_chunk(url=url, offset=offset, size=length, data=val)
+                else:
+                    print(f'Warning: not caching chunk of size {length} om LindiReferenceFileSystemStore (key: {key})')
             return val
         else:
             # should not happen given checks in __init__, but self.rfs is mutable

--- a/lindi/LindiRemfile/LindiRemfile.py
+++ b/lindi/LindiRemfile/LindiRemfile.py
@@ -218,15 +218,12 @@ class LindiRemfile:
                 self._memory_chunks[chunk_index] = x
             if self._local_cache is not None:
                 size = min(self._min_chunk_size, self.length - chunk_index * self._min_chunk_size)
-                if size < 1000 * 1000 * 900:
-                    self._local_cache.put_remote_chunk(
-                        url=self._url,
-                        offset=chunk_index * self._min_chunk_size,
-                        size=size,
-                        data=x
-                    )
-                else:
-                    raise Exception(f'Unexpected large size for chunk when caching: {size}')
+                self._local_cache.put_remote_chunk(
+                    url=self._url,
+                    offset=chunk_index * self._min_chunk_size,
+                    size=size,
+                    data=x
+                )
             self._memory_chunk_indices.append(chunk_index)
         else:
             for i in range(self._smart_loader_chunk_sequence_length):
@@ -242,15 +239,12 @@ class LindiRemfile:
                     data = x[i * self._min_chunk_size: (i + 1) * self._min_chunk_size]
                     if len(data) != size:
                         raise ValueError(f'Unexpected: len(data) != size: {len(data)} != {size}')
-                    if size < 1000 * 1000 * 900:
-                        self._local_cache.put_remote_chunk(
-                            url=self._url,
-                            offset=(chunk_index + i) * self._min_chunk_size,
-                            size=size,
-                            data=data
-                        )
-                    else:
-                        raise Exception(f'Unexpected large size for chunk when caching: {size}')
+                    self._local_cache.put_remote_chunk(
+                        url=self._url,
+                        offset=(chunk_index + i) * self._min_chunk_size,
+                        size=size,
+                        data=data
+                    )
         self._smart_loader_last_chunk_index_accessed = (
             chunk_index + self._smart_loader_chunk_sequence_length - 1
         )

--- a/lindi/LocalCache/LocalCache.py
+++ b/lindi/LocalCache/LocalCache.py
@@ -18,6 +18,11 @@ class LocalCache:
     def put_remote_chunk(self, *, url: str, offset: int, size: int, data: bytes):
         if len(data) != size:
             raise ValueError("data size does not match size")
+        if size >= 1000 * 1000 * 900:
+            # This is a sqlite limitation/configuration
+            # https://www.sqlite.org/limits.html
+            # For some reason 1000 * 1000 * 1000 seems to be too large, whereas 1000 * 1000 * 900 is fine
+            raise ValueError("Cannot store blobs larger than 900 MB in LocalCache")
         self._sqlite_client.put_remote_chunk(url=url, offset=offset, size=size, data=data)
 
 

--- a/lindi/__init__.py
+++ b/lindi/__init__.py
@@ -1,5 +1,5 @@
 from .LindiH5ZarrStore import LindiH5ZarrStore, LindiH5ZarrStoreOpts  # noqa: F401
 from .LindiH5pyFile import LindiH5pyFile, LindiH5pyGroup, LindiH5pyDataset, LindiH5pyHardLink, LindiH5pySoftLink  # noqa: F401
 from .LindiStagingStore import LindiStagingStore, StagingArea  # noqa: F401
-from .LocalCache.LocalCache import LocalCache  # noqa: F401
+from .LocalCache.LocalCache import LocalCache, ChunkTooLargeError  # noqa: F401
 from .File.File import File  # noqa: F401

--- a/tests/test_local_cache.py
+++ b/tests/test_local_cache.py
@@ -45,5 +45,31 @@ def test_remote_data_1():
                 assert elapsed_1 < elapsed_0 * 0.3  # type: ignore
 
 
+def test_put_local_cache():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        local_cache = lindi.LocalCache(cache_dir=tmpdir + '/local_cache')
+        data = b'x' * (1000 * 1000 * 900 - 1)
+        local_cache.put_remote_chunk(
+            url='dummy',
+            offset=0,
+            size=len(data),
+            data=data
+        )
+        data2 = local_cache.get_remote_chunk(
+            url='dummy',
+            offset=0,
+            size=len(data)
+        )
+        assert data == data2
+        data_too_large = b'x' * (1000 * 1000 * 900)
+        with pytest.raises(ValueError):
+            local_cache.put_remote_chunk(
+                url='dummy',
+                offset=0,
+                size=len(data_too_large),
+                data=data_too_large
+            )
+
+
 if __name__ == "__main__":
-    test_remote_data_1()
+    test_put_local_cache()

--- a/tests/test_local_cache.py
+++ b/tests/test_local_cache.py
@@ -62,7 +62,7 @@ def test_put_local_cache():
         )
         assert data == data2
         data_too_large = b'x' * (1000 * 1000 * 900)
-        with pytest.raises(ValueError):
+        with pytest.raises(lindi.ChunkTooLargeError):
             local_cache.put_remote_chunk(
                 url='dummy',
                 offset=0,


### PR DESCRIPTION
I found a situation where the chunk size was larger than 1 GB and the sqllite save failed. This particular dataset was not chunked, and this should not be an issue for most dandisets where chunk sizes are reasonable.

So with this PR I limit the size of chunks in local cache to 900 MB.

See https://www.sqlite.org/limits.html

(For some reason, despite what it says in that limits.html, it seems that 1000 MB doesn't work whereas 900 MB does)

For LindiH5ZarrStore and LindiReferenceFileSystemStore, I display a warning if the chunk size is too large, and then skip storing it in local cache. For LindiRemfile I raise an exception because this should never happen in that context.

I added a test.