### PR TITLE
Implement `LindiReferenceFileSystemStore.__contains__`

### DIFF
--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -115,6 +115,9 @@ class LindiReferenceFileSystemStore(ZarrStore):
         self.local_cache = local_cache
 
     # These methods are overridden from MutableMapping
+    def __contains__(self, key: str):
+        return key in self.rfs["refs"]
+
     def __getitem__(self, key: str):
         if key not in self.rfs["refs"]:
             raise KeyError(key)
@@ -251,6 +254,7 @@ def _read_bytes_from_url_or_path(url_or_path: str, offset: int, length: int):
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
             "Range": range_header
         }
+        print(headers)
         response = requests.get(url_resolved, headers=headers)
         response.raise_for_status()
         return response.content

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -254,7 +254,6 @@ def _read_bytes_from_url_or_path(url_or_path: str, offset: int, length: int):
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
             "Range": range_header
         }
-        print(headers)
         response = requests.get(url_resolved, headers=headers)
         response.raise_for_status()
         return response.content


### PR DESCRIPTION
`MutableMapping` implements `__contains__` by calling `__getitem__` and checking for None. Zarr `BaseStore` has this line: 
https://github.com/zarr-developers/zarr-python/blob/b1f4c509abaee1cb8dec18e3a973e1199226011a/src/zarr/v2/_storage/store.py#L142

which does a both `__contains__` check and `__getitem__` check. That results in two remote requests per `__getitem__` call in `LindiReferenceFileSystemStore`. 

This PR removes the remote request for `__contains__`.