### PR TITLE
Fix handling of datasets with shape (0,0,...)

### DIFF
--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -115,7 +115,9 @@ class LindiReferenceFileSystemStore(ZarrStore):
         self.local_cache = local_cache
 
     # These methods are overridden from MutableMapping
-    def __contains__(self, key: str):
+    def __contains__(self, key: object):
+        if not isinstance(key, str):
+            return False
         return key in self.rfs["refs"]
 
     def __getitem__(self, key: str):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -575,5 +575,27 @@ def test_numpy_array_of_byte_strings():
             assert lists_are_equal(X1[:].tolist(), X2[:].tolist())  # type: ignore
 
 
+def test_dataset_zero_shape():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = f"{tmpdir}/test.h5"
+        with h5py.File(filename, "w") as f:
+            f.create_dataset("X1D", data=np.array([], dtype=np.int32), shape=(0,))  # NOTE this is not a scalar
+            f.create_dataset("X3D", data=np.array([], dtype=np.int32), shape=(0,0,0))
+        h5f = h5py.File(filename, "r")
+        with LindiH5ZarrStore.from_file(filename, url=filename) as store:
+            rfs = store.to_reference_file_system()
+            h5f_2 = lindi.LindiH5pyFile.from_reference_file_system(rfs)
+            X1 = h5f['X1D']
+            assert isinstance(X1, h5py.Dataset)
+            X2 = h5f_2['X1D']
+            assert isinstance(X2, h5py.Dataset)
+            assert arrays_are_equal(X1[:], X2[:])
+            X1 = h5f['X3D']
+            assert isinstance(X1, h5py.Dataset)
+            X2 = h5f_2['X3D']
+            assert isinstance(X2, h5py.Dataset)
+            assert arrays_are_equal(X1[:], X2[:])
+
+
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
Fix #76.

For an HDF5 dataset with shape (0,0,0), no chunks should be written. This was the previous behavior before #68 and seems reasonable. 

For an HDF5 dataset with shape (0,0,0), the `chunks` key in `.zarray` was being set to (0,0,0). However, that is not allowed in Zarr. Accessing an array with such chunking results in a `ZeroDivisionError: division by zero` when trying to access the array. I set it to (1,1,1) instead which is what Zarr does for an array of that shape.

```python
>>> import zarr
>>> a = zarr.empty(shape=(0,0,0))
>>> a.shape
(0, 0, 0)
>>> a.chunks
(1, 1, 1)
>>> a[:]
array([], shape=(0, 0, 0), dtype=float64)
>>> a = zarr.empty(shape=(0,0,0), chunks=(0,0,0))
>>> a.chunks
(0, 0, 0)
>>> a[:]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rly/mambaforge/envs/test4/lib/python3.11/site-packages/zarr/core.py", line 800, in __getitem__
    result = self.get_basic_selection(pure_selection, fields=fields)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rly/mambaforge/envs/test4/lib/python3.11/site-packages/zarr/core.py", line 926, in get_basic_selection
    return self._get_basic_selection_nd(selection=selection, out=out, fields=fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rly/mambaforge/envs/test4/lib/python3.11/site-packages/zarr/core.py", line 966, in _get_basic_selection_nd
    indexer = BasicIndexer(selection, self)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rly/mambaforge/envs/test4/lib/python3.11/site-packages/zarr/indexing.py", line 339, in __init__
    dim_indexer = SliceDimIndexer(dim_sel, dim_len, dim_chunk_len)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rly/mambaforge/envs/test4/lib/python3.11/site-packages/zarr/indexing.py", line 181, in __init__
    self.nchunks = ceildiv(self.dim_len, self.dim_chunk_len)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rly/mambaforge/envs/test4/lib/python3.11/site-packages/zarr/indexing.py", line 167, in ceildiv
    return math.ceil(a / b)
                     ~~^~~
ZeroDivisionError: division by zero
```

I also fixed an issue flagged by pyright in `LindiReferenceFileSystemStore.__contains__`: 
```
error: Method "__contains__" overrides class "Mapping" in an incompatible manner
    Parameter 2 type mismatch: base parameter is type "object", override parameter is type "str"`
```