### PR TITLE
WIP: add single_chunk_size_threshold opt

### DIFF
--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -519,11 +519,11 @@ class LindiH5ZarrStore(Store):
             if expected_num_chunks > self._opts.num_dataset_chunks_threshold:
                 use_external_array_link = True
 
-        # Or if we have a single chunk that is very large, then we create an
-        # external array link.
-        if self._opts.single_chunk_size_threshold is not None:
-            if expected_num_chunks == 1:
-                if np.prod(h5_item.shape) > self._opts.single_chunk_size_threshold:
+        # Or if we have a single uncompressed chunk that is very large, then we
+        # create an external array link.
+        if self._opts.single_uncompressed_chunk_size_threshold is not None:
+            if expected_num_chunks == 1 and h5_item.compression is None:
+                if np.prod(h5_item.shape) * h5_item.dtype.itemsize > self._opts.single_uncompressed_chunk_size_threshold:
                     use_external_array_link = True
 
         if use_external_array_link:

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
@@ -10,12 +10,14 @@ class LindiH5ZarrStoreOpts:
     Attributes:
         num_dataset_chunks_threshold (Union[int, None]): For each dataset in the
         HDF5 file, if the number of chunks is greater than this threshold, then
-        the dataset will be represented as an external array link. Default is 1000.
+        the dataset will be represented as an external array link. Default is
+        1000.
 
-        single_chunk_size_threshold (Union[int, None]): For each dataset in the
-        HDF5 file, if the dataset is a single chunk and the size of the chunk
-        is greater than this threshold, then the dataset will be represented as
-        an external array link. Default is 1000 * 1000 * 100.
+        single_uncompressed_chunk_size_threshold (Union[int, None]): For each
+        dataset in the HDF5 file, if the dataset is a single uncompressed chunk
+        and the size of the chunk is greater than this threshold in bytes, then
+        the dataset will be represented as an external array link. Default is
+        1000 * 1000 * 100.
     """
     num_dataset_chunks_threshold: Union[int, None] = 1000
-    single_chunk_size_threshold: Union[int, None] = 1000 * 1000 * 100
+    single_uncompressed_chunk_size_threshold: Union[int, None] = 1000 * 1000 * 100

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
@@ -10,8 +10,12 @@ class LindiH5ZarrStoreOpts:
     Attributes:
         num_dataset_chunks_threshold (Union[int, None]): For each dataset in the
         HDF5 file, if the number of chunks is greater than this threshold, then
-        the dataset will be represented as an external array link. If None, then
-        no datasets will be represented as external array links (equivalent to a
-        threshold of 0). Default is 1000.
+        the dataset will be represented as an external array link. Default is 1000.
+
+        single_chunk_size_threshold (Union[int, None]): For each dataset in the
+        HDF5 file, if the dataset is a single chunk and the size of the chunk
+        is greater than this threshold, then the dataset will be represented as
+        an external array link. Default is 1000 * 1000 * 100.
     """
     num_dataset_chunks_threshold: Union[int, None] = 1000
+    single_chunk_size_threshold: Union[int, None] = 1000 * 1000 * 100

--- a/tests/test_local_cache.py
+++ b/tests/test_local_cache.py
@@ -42,7 +42,7 @@ def test_remote_data_1():
                 elapsed_0 = elapsed
             if passnum == 1:
                 elapsed_1 = elapsed
-                assert elapsed_1 < elapsed_0 * 0.3  # type: ignore
+                assert elapsed_1 < elapsed_0 * 0.6  # type: ignore
 
 
 def test_put_local_cache():


### PR DESCRIPTION
@rly

I've been running into a problem where some of the large (raw ephys) datasets on DANDI are uncompressed and stored in a single very large chunk within the NWB file. For example [000935](https://neurosift.app/?p=/dandiset&dandisetId=000935&dandisetVersion=draft). In fact, as you know, the default in HDF5 is to create an uncompressed contiguous chunk. This is a problem for Zarr with remote files because (as far as I can see) there is no such thing as a partial read of a chunk. So if I try to randomly access a time segment with one of these arrays, the entire chunk/dataset needs to be downloaded.

This problem could potentially be addressed at various stages of the flow, but at this point I haven't found any that are satisfactory.

As a workaround, in this PR I have added another attribute to the LindiH5ZarrStoreOpts called single_uncompressed_chunk_size_threshold which defaults to 100 MB. It detects the situation where the dataset is a single uncompressed chunk of size greater than 100 MB. In this case, it is marked as an external array link. So in this case, when the client loads the array, it falls back to loading the data using h5py reader, which is capable of slicing the data efficiently.