### PR TITLE
Split large unchunked contiguous HDF5 datasets into smaller chunks

### DIFF
--- a/.github/workflows/linter_checks.yml
+++ b/.github/workflows/linter_checks.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Run flake8
       run: cd lindi && flake8 --config ../.flake8
     - name: Run pyright
-      run: cd lindi && pyright
+      run: cd lindi && pyright .

--- a/.vscode/tasks/test.sh
+++ b/.vscode/tasks/test.sh
@@ -5,7 +5,7 @@ set -ex
 
 cd lindi
 flake8 .
-pyright
+pyright .
 cd ..
 
 pytest --cov=lindi --cov-report=xml --cov-report=term tests/

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -25,6 +25,100 @@ from ..LindiRemfile.LindiRemfile import LindiRemfile
 from .LindiH5ZarrStoreOpts import LindiH5ZarrStoreOpts
 
 
+class SplitDatasetH5Item:
+    """
+    Represents a dataset that is a single contiguous chunk in the hdf5 file, but
+    is split into multiple chunks for efficient slicing in the zarr store.
+    """
+    def __init__(self, h5_item, *, contiguous_dataset_max_chunk_size: Union[int, None]):
+        self._h5_item = h5_item
+        self._contiguous_dataset_max_chunk_size = contiguous_dataset_max_chunk_size
+        should_split = False
+        if contiguous_dataset_max_chunk_size is not None:
+            codecs = h5_filters_to_codecs(h5_item)
+            if codecs is None or len(codecs) == 0:  # does not have compression
+                if h5_item.chunks is None or h5_item.chunks == h5_item.shape:  # only one chunk
+                    if h5_item.dtype.kind in ['i', 'u', 'f']:  # integer or float
+                        size_bytes = int(np.prod(h5_item.shape)) * h5_item.dtype.itemsize
+                        if size_bytes > contiguous_dataset_max_chunk_size:  # large enough to split
+                            should_split = True
+        self._do_split = should_split
+        if should_split:
+            size0 = int(np.prod(h5_item.shape[1:])) * h5_item.dtype.itemsize
+            nn = contiguous_dataset_max_chunk_size // size0
+            self._split_chunk_shape = (nn,) + h5_item.shape[1:]
+            if h5_item.chunks is not None:
+                zero_chunk_coords = (0,) * h5_item.ndim
+                try:
+                    byte_offset, byte_count = _get_chunk_byte_range(h5_item, zero_chunk_coords)
+                except Exception as e:
+                    raise Exception(
+                        f"Error getting byte range for chunk when trying to split contiguous dataset {h5_item.name}: {e}"
+                    )
+            else:
+                # Get the byte range in the file for the contiguous dataset
+                byte_offset, byte_count = _get_byte_range_for_contiguous_dataset(h5_item)
+            self._split_chunk_byte_offset = byte_offset
+            self._split_chunk_byte_count = byte_count
+            self._num_chunks = int(np.prod(h5_item.shape[0:]) + np.prod(self._split_chunk_shape) - 1) // int(np.prod(self._split_chunk_shape))
+        else:
+            self._split_chunk_shape = None
+            self._split_chunk_byte_offset = None
+            self._split_chunk_byte_count = None
+            self._num_chunks = None
+
+    def get_chunk_byte_range(self, chunk_coords: Tuple[int, ...]):
+        if len(chunk_coords) != self.ndim:
+            raise Exception(f"SplitDatasetH5Item: Chunk coordinates {chunk_coords} do not match dataset dimensions")
+        for i in range(1, len(chunk_coords)):
+            if chunk_coords[i] != 0:
+                raise Exception(f"SplitDatasetH5Item: Unexpected non-zero chunk coordinate {chunk_coords[i]}")
+        if self._split_chunk_byte_offset is None:
+            raise Exception("SplitDatasetH5Item: Unexpected _split_chunk_byte_offset is None")
+        if self._split_chunk_shape is None:
+            raise Exception("SplitDatasetH5Item: Unexpected _split_chunk_shape is None")
+        chunk_index = chunk_coords[0]
+        byte_offset = self._split_chunk_byte_offset + chunk_index * int(np.prod(self._split_chunk_shape)) * self.dtype.itemsize
+        byte_count = int(np.prod(self._split_chunk_shape)) * self.dtype.itemsize
+        if byte_offset + byte_count > self._split_chunk_byte_offset + self._split_chunk_byte_count:
+            byte_count = self._split_chunk_byte_offset + self._split_chunk_byte_count - byte_offset
+        return byte_offset, byte_count
+
+    @property
+    def shape(self):
+        return self._h5_item.shape
+
+    @property
+    def dtype(self):
+        return self._h5_item.dtype
+
+    @property
+    def name(self):
+        return self._h5_item.name
+
+    @property
+    def chunks(self):
+        if self._do_split:
+            return self._split_chunk_shape
+        return self._h5_item.chunks
+
+    @property
+    def ndim(self):
+        return self._h5_item.ndim
+
+    @property
+    def fillvalue(self):
+        return self._h5_item.fillvalue
+
+    @property
+    def attrs(self):
+        return self._h5_item.attrs
+
+    @property
+    def size(self):
+        return self._h5_item.size
+
+
 class LindiH5ZarrStore(Store):
     """A zarr store that provides a read-only view of an HDF5 file.
 
@@ -64,6 +158,9 @@ class LindiH5ZarrStore(Store):
         # those datasets, we need to store the inline data so that we can return
         # it when the chunk is requested.
         self._inline_arrays: Dict[str, InlineArray] = {}
+
+        # For large contiguous arrays, we want to split them into smaller chunks.
+        self._split_datasets: Dict[str, SplitDatasetH5Item] = {}
 
         self._external_array_links: Dict[str, Union[dict, None]] = {}
 
@@ -180,6 +277,8 @@ class LindiH5ZarrStore(Store):
                 return False
             if not isinstance(h5_item, h5py.Dataset):
                 return False
+            if self._split_datasets.get(key_parent, None) is not None:
+                h5_item = self._split_datasets[key_parent]
             external_array_link = self._get_external_array_link(key_parent, h5_item)
             if external_array_link is not None:
                 # The chunk files do not exist for external array links
@@ -278,7 +377,7 @@ class LindiH5ZarrStore(Store):
         zarr.group(store=memory_store)
         return reformat_json(memory_store.get(".zgroup"))
 
-    def _get_inline_array(self, key: str, h5_dataset: h5py.Dataset):
+    def _get_inline_array(self, key: str, h5_dataset: Union[h5py.Dataset, SplitDatasetH5Item]):
         if key in self._inline_arrays:
             return self._inline_arrays[key]
         self._inline_arrays[key] = InlineArray(h5_dataset)
@@ -298,6 +397,11 @@ class LindiH5ZarrStore(Store):
             return inline_array.zarray_bytes
 
         filters = h5_filters_to_codecs(h5_item)
+
+        split_dataset = SplitDatasetH5Item(h5_item, contiguous_dataset_max_chunk_size=self._opts.contiguous_dataset_max_chunk_size)
+        if split_dataset._do_split:
+            self._split_datasets[parent_key] = split_dataset
+            h5_item = split_dataset
 
         # We create a dummy zarr dataset with the appropriate shape, chunks,
         # dtype, and filters and then copy the .zarray JSON text from it
@@ -370,6 +474,9 @@ class LindiH5ZarrStore(Store):
         if not isinstance(h5_item, h5py.Dataset):
             raise Exception(f"Item {key_parent} is not a dataset")
 
+        if self._split_datasets.get(key_parent, None) is not None:
+            h5_item = self._split_datasets[key_parent]
+
         external_array_link = self._get_external_array_link(key_parent, h5_item)
         if external_array_link is not None:
             raise Exception(
@@ -418,7 +525,10 @@ class LindiH5ZarrStore(Store):
         if h5_item.chunks is not None:
             # Get the byte range in the file for the chunk.
             try:
-                byte_offset, byte_count = _get_chunk_byte_range(h5_item, chunk_coords)
+                if isinstance(h5_item, SplitDatasetH5Item):
+                    byte_offset, byte_count = h5_item.get_chunk_byte_range(chunk_coords)
+                else:
+                    byte_offset, byte_count = _get_chunk_byte_range(h5_item, chunk_coords)
             except Exception as e:
                 raise Exception(
                     f"Error getting byte range for chunk {key_parent}/{key_name}. Shape: {h5_item.shape}, Chunks: {h5_item.chunks}, Chunk coords: {chunk_coords}: {e}"
@@ -430,6 +540,8 @@ class LindiH5ZarrStore(Store):
                 raise Exception(
                     f"Chunk coordinates {chunk_coords} are not (0, 0, 0, ...) for contiguous dataset {key_parent} with dtype {h5_item.dtype} and shape {h5_item.shape}"
                 )
+            if isinstance(h5_item, SplitDatasetH5Item):
+                raise Exception(f'Unexpected SplitDatasetH5Item for contiguous dataset {key_parent}')
             # Get the byte range in the file for the contiguous dataset
             byte_offset, byte_count = _get_byte_range_for_contiguous_dataset(h5_item)
         return byte_offset, byte_count, None
@@ -439,6 +551,9 @@ class LindiH5ZarrStore(Store):
             raise Exception("Store is closed")
         h5_item = self._h5f.get('/' + key_parent, None)
         assert isinstance(h5_item, h5py.Dataset)
+
+        if self._split_datasets.get(key_parent, None) is not None:
+            h5_item = self._split_datasets[key_parent]
 
         # If the shape is (0,), (0, 0), (0, 0, 0), etc., then do not add any chunk references
         if np.prod(h5_item.shape) == 0:
@@ -467,7 +582,7 @@ class LindiH5ZarrStore(Store):
             # does not provide a way to hook in a progress bar
             # We use max number of chunks instead of actual number of chunks because get_num_chunks is slow
             # for remote datasets.
-            num_chunks = _get_max_num_chunks(h5_item)  # NOTE: unallocated chunks are counted
+            num_chunks = _get_max_num_chunks(shape=h5_item.shape, chunk_size=h5_item.chunks)  # NOTE: unallocated chunks are counted
             pbar = tqdm(
                 total=num_chunks,
                 desc=f"Writing chunk info for {key_parent}",
@@ -477,24 +592,35 @@ class LindiH5ZarrStore(Store):
 
             chunk_size = h5_item.chunks
 
-            def store_chunk_info(chunk_info):
-                # Get the byte range in the file for each chunk.
-                chunk_offset: Tuple[int, ...] = chunk_info.chunk_offset
-                byte_offset = chunk_info.byte_offset
-                byte_count = chunk_info.size
-                key_name = ".".join([str(a // b) for a, b in zip(chunk_offset, chunk_size)])
-                add_ref_chunk(f"{key_parent}/{key_name}", (self._url, byte_offset, byte_count))
-                pbar.update()
+            if isinstance(h5_item, SplitDatasetH5Item):
+                assert h5_item._num_chunks is not None, "Unexpected: _num_chunks is None"
+                for i in range(h5_item._num_chunks):
+                    chunk_coords = (i,) + (0,) * (h5_item.ndim - 1)
+                    byte_offset, byte_count = h5_item.get_chunk_byte_range(chunk_coords)
+                    key_name = ".".join([str(x) for x in chunk_coords])
+                    add_ref_chunk(f"{key_parent}/{key_name}", (self._url, byte_offset, byte_count))
+                    pbar.update()
+            else:
+                def store_chunk_info(chunk_info):
+                    # Get the byte range in the file for each chunk.
+                    chunk_offset: Tuple[int, ...] = chunk_info.chunk_offset
+                    byte_offset = chunk_info.byte_offset
+                    byte_count = chunk_info.size
+                    key_name = ".".join([str(a // b) for a, b in zip(chunk_offset, chunk_size)])
+                    add_ref_chunk(f"{key_parent}/{key_name}", (self._url, byte_offset, byte_count))
+                    pbar.update()
 
-            _apply_to_all_chunk_info(h5_item, store_chunk_info)
+                _apply_to_all_chunk_info(h5_item, store_chunk_info)
+
             pbar.close()
         else:
             # Get the byte range in the file for the contiguous dataset
+            assert not isinstance(h5_item, SplitDatasetH5Item), "Unexpected SplitDatasetH5Item for contiguous dataset"
             byte_offset, byte_count = _get_byte_range_for_contiguous_dataset(h5_item)
             key_name = ".".join("0" for _ in range(h5_item.ndim))
             add_ref_chunk(f"{key_parent}/{key_name}", (self._url, byte_offset, byte_count))
 
-    def _get_external_array_link(self, parent_key: str, h5_item: h5py.Dataset):
+    def _get_external_array_link(self, parent_key: str, h5_item: Union[h5py.Dataset, SplitDatasetH5Item]):
         # First check the memory cache
         if parent_key in self._external_array_links:
             return self._external_array_links[parent_key]
@@ -510,7 +636,7 @@ class LindiH5ZarrStore(Store):
                 (shape[i] + chunks[i] - 1) // chunks[i] if chunks[i] != 0 else 0
                 for i in range(len(shape))
             ]
-            num_chunks = np.prod(chunk_coords_shape)
+            num_chunks = int(np.prod(chunk_coords_shape))
             if num_chunks > self._opts.num_dataset_chunks_threshold:
                 if self._url is not None:
                     self._external_array_links[parent_key] = {
@@ -663,7 +789,7 @@ class LindiH5ZarrStore(Store):
 
 
 class InlineArray:
-    def __init__(self, h5_dataset: h5py.Dataset):
+    def __init__(self, h5_dataset: Union[h5py.Dataset, SplitDatasetH5Item]):
         self._additional_zarr_attributes = {}
         if h5_dataset.shape == ():
             self._additional_zarr_attributes["_SCALAR"] = True
@@ -686,9 +812,15 @@ class InlineArray:
                 # For example: [['x', 'uint32'], ['y', 'uint32'], ['weight', 'float32']]
                 self._additional_zarr_attributes["_COMPOUND_DTYPE"] = compound_dtype
         if self._is_inline:
+            if isinstance(h5_dataset, SplitDatasetH5Item):
+                raise Exception('SplitDatasetH5Item should not be an inline array')
             memory_store = MemoryStore()
             dummy_group = zarr.group(store=memory_store)
             size_is_zero = np.prod(h5_dataset.shape) == 0
+            if isinstance(h5_dataset, SplitDatasetH5Item):
+                h5_item = h5_dataset._h5_item
+            else:
+                h5_item = h5_dataset
             create_zarr_dataset_from_h5_data(
                 zarr_parent_group=dummy_group,
                 name='X',
@@ -700,8 +832,8 @@ class InlineArray:
                 label=f'{h5_dataset.name}',
                 h5_shape=h5_dataset.shape,
                 h5_dtype=h5_dataset.dtype,
-                h5f=h5_dataset.file,
-                h5_data=h5_dataset[...]
+                h5f=h5_item.file,
+                h5_data=h5_item[...]
             )
             self._zarray_bytes = reformat_json(memory_store['X/.zarray'])
             if not size_is_zero:

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStore.py
@@ -41,7 +41,6 @@ class SplitDatasetH5Item:
                 if h5_item.chunks is None or h5_item.chunks == h5_item.shape:  # only one chunk
                     if h5_item.dtype.kind in ['i', 'u', 'f']:  # integer or float
                         size_bytes = int(np.prod(h5_item.shape)) * h5_item.dtype.itemsize
-                        print('---- size_bytes', size_bytes)
                         if size_bytes > contiguous_dataset_max_chunk_size:  # large enough to split
                             should_split = True
         self._do_split = should_split
@@ -70,7 +69,6 @@ class SplitDatasetH5Item:
                 byte_offset, byte_count = _get_byte_range_for_contiguous_dataset(h5_item)
             self._split_chunk_byte_offset = byte_offset
             self._split_chunk_byte_count = byte_count
-            print('----', h5_item.shape, self._split_chunk_shape)
             self._num_chunks = int(np.prod(h5_item.shape[0:]) + np.prod(self._split_chunk_shape) - 1) // int(np.prod(self._split_chunk_shape))
         else:
             self._split_chunk_shape = None

--- a/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
+++ b/lindi/LindiH5ZarrStore/LindiH5ZarrStoreOpts.py
@@ -13,5 +13,12 @@ class LindiH5ZarrStoreOpts:
         the dataset will be represented as an external array link. If None, then
         no datasets will be represented as external array links (equivalent to a
         threshold of 0). Default is 1000.
+
+        contiguous_dataset_max_chunk_size (Union[int, None]): For large
+        contiguous arrays in the hdf5 file that are not chunked, this option
+        specifies the maximum size in bytes of the zarr chunks that will be
+        created. If None, then the entire array will be represented as a single
+        chunk. Default is 1000 * 1000 * 20
     """
     num_dataset_chunks_threshold: Union[int, None] = 1000
+    contiguous_dataset_max_chunk_size: Union[int, None] = 1000 * 1000 * 20

--- a/lindi/LindiH5ZarrStore/_util.py
+++ b/lindi/LindiH5ZarrStore/_util.py
@@ -12,15 +12,16 @@ def _read_bytes(file: IO, offset: int, count: int):
     return file.read(count)
 
 
-def _get_max_num_chunks(h5_dataset: h5py.Dataset):
+def _get_max_num_chunks(*, shape, chunk_size):
     """Get the maximum number of chunks in an h5py dataset.
 
     This is similar to h5_dataset.id.get_num_chunks() but significantly faster. It does not account for
     whether some chunks are allocated.
     """
-    chunk_size = h5_dataset.chunks
     assert chunk_size is not None
-    return math.prod([math.ceil(a / b) for a, b in zip(h5_dataset.shape, chunk_size)])
+    if np.prod(chunk_size) == 0:
+        return 0
+    return math.prod([math.ceil(a / b) for a, b in zip(shape, chunk_size)])
 
 
 def _apply_to_all_chunk_info(h5_dataset: h5py.Dataset, callback: Callable):

--- a/lindi/LindiH5pyFile/LindiH5pyFile.py
+++ b/lindi/LindiH5pyFile/LindiH5pyFile.py
@@ -449,6 +449,9 @@ class LindiH5pyFile(h5py.File):
     def keys(self):  # type: ignore
         return self._the_group.keys()
 
+    def items(self):
+        return self._the_group.items()
+
     def __iter__(self):
         return self._the_group.__iter__()
 

--- a/lindi/LindiH5pyFile/LindiH5pyFile.py
+++ b/lindi/LindiH5pyFile/LindiH5pyFile.py
@@ -446,6 +446,9 @@ class LindiH5pyFile(h5py.File):
             raise Exception("Getting class is not allowed")
         return self._get_item(name, getlink=getlink, default=default)
 
+    def keys(self):  # type: ignore
+        return self._the_group.keys()
+
     def __iter__(self):
         return self._the_group.__iter__()
 

--- a/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
+++ b/lindi/LindiH5pyFile/LindiReferenceFileSystemStore.py
@@ -124,7 +124,10 @@ class LindiReferenceFileSystemStore(ZarrStore):
     def __getitem__(self, key: str):
         val = self._get_helper(key)
 
-        # Here's the hack
+        # If the key is a chunk and it's smaller than the expected size, then we
+        # need to pad it with zeros. This can happen if this is the final chunk
+        # in a contiguous hdf5 dataset. See
+        # https://github.com/NeurodataWithoutBorders/lindi/pull/84
         base_key = key.split('/')[-1]
         if val and _is_chunk_base_key(base_key):
             parent_key = key.split('/')[:-1]
@@ -136,9 +139,10 @@ class LindiReferenceFileSystemStore(ZarrStore):
                 chunk_shape = zarray['chunks']
                 dtype = zarray['dtype']
                 expected_chunk_size = int(np.prod(chunk_shape)) * _get_itemsize(dtype)
-                if len(val) != expected_chunk_size:
-                    # we need to pad it
+                if len(val) < expected_chunk_size:
                     val = _pad_chunk(val, expected_chunk_size)
+                elif len(val) > expected_chunk_size:
+                    raise Exception(f"Chunk size is larger than expected: {len(val)} > {expected_chunk_size}")
 
         return val
 

--- a/lindi/conversion/create_zarr_dataset_from_h5_data.py
+++ b/lindi/conversion/create_zarr_dataset_from_h5_data.py
@@ -117,7 +117,7 @@ def create_zarr_dataset_from_h5_data(
                 # than 1 million elements. This is because zarr may default to
                 # suboptimal chunking. Note that the default for h5py is to use the
                 # entire dataset as a single chunk.
-                total_size = np.prod(h5_shape) if len(h5_shape) > 0 else 1
+                total_size = int(np.prod(h5_shape)) if len(h5_shape) > 0 else 1
                 if total_size > 1000 * 1000:
                     raise Exception(f'Chunks must be specified explicitly when writing dataset of shape {h5_shape}')
             # Note that we are not using the same filters as in the h5py dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lindi"
-version = "0.3.12"
+version = "0.3.13"
 description = ""
 authors = [
     "Jeremy Magland <jmagland@flatironinstitute.org>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lindi"
-version = "0.3.10"
+version = "0.3.12"
 description = ""
 authors = [
     "Jeremy Magland <jmagland@flatironinstitute.org>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lindi"
-version = "0.3.13"
+version = "0.3.14"
 description = ""
 authors = [
     "Jeremy Magland <jmagland@flatironinstitute.org>",

--- a/tests/test_local_cache.py
+++ b/tests/test_local_cache.py
@@ -42,7 +42,7 @@ def test_remote_data_1():
                 elapsed_0 = elapsed
             if passnum == 1:
                 elapsed_1 = elapsed
-                assert elapsed_1 < elapsed_0 * 0.3  # type: ignore
+                assert elapsed_1 < elapsed_0 * 0.6  # type: ignore
 
 
 def test_put_local_cache():

--- a/tests/test_split_contiguous_dataset.py
+++ b/tests/test_split_contiguous_dataset.py
@@ -1,0 +1,29 @@
+import pytest
+import lindi
+import h5py
+
+
+@pytest.mark.network
+def test_split_contiguous_dataset():
+    # https://neurosift.app/?p=/nwb&dandisetId=000935&dandisetVersion=draft&url=https://api.dandiarchive.org/api/assets/e18e787a-544a-438e-8396-f396efb3bd3d/download/
+    h5_url = "https://api.dandiarchive.org/api/assets/e18e787a-544a-438e-8396-f396efb3bd3d/download/"
+
+    opts = lindi.LindiH5ZarrStoreOpts(
+        contiguous_dataset_max_chunk_size=1000 * 1000 * 17
+    )
+    x = lindi.LindiH5pyFile.from_hdf5_file(h5_url, zarr_store_opts=opts)
+    d = x['acquisition/ElectricalSeries/data']
+    assert isinstance(d, h5py.Dataset)
+    print(d.shape)
+    assert d[0][0] == 6.736724784228119e-06
+    assert d[10 * 1000 * 1000][0] == -1.0145925267155008e-06
+    rfs = x.to_reference_file_system()
+    zarray = rfs['refs']['acquisition/ElectricalSeries/data/.zarray']
+    assert zarray['chunks'] == [66406, 32]
+    aa = rfs['refs']['acquisition/ElectricalSeries/data/5.0']
+    assert aa[1] == 2415072880
+    assert aa[2] == 16999936
+
+
+if __name__ == "__main__":
+    test_split_contiguous_dataset()


### PR DESCRIPTION
This is a third attempt at #82 and #83 

This solves the following important problem. Some of the large (raw ephys) datasets on DANDI are uncompressed and stored in a single very large chunk within the NWB file. For example [000935](https://neurosift.app/?p=/dandiset&dandisetId=000935&dandisetVersion=draft). In fact, the default in HDF5 is to create an uncompressed contiguous chunk. This is a problem for Zarr with remote files because (as far as I can see) there is no such thing as a partial read of a Zarr chunk. So if I try to randomly access a time segment with one of these arrays, the entire chunk/dataset needs to be downloaded.

This PR modifies LindiH5ZarrStore so that such datasets are effectively split into smaller chunks within the reference file system.