### PR TITLE
Additional url resolver needed by dendro

### DIFF
--- a/lindi/LindiRemfile/LindiRemfile.py
+++ b/lindi/LindiRemfile/LindiRemfile.py
@@ -2,6 +2,7 @@ from typing import Union
 import time
 import os
 import requests
+from .additional_url_resolvers import get_additional_url_resolvers
 from ..LocalCache.LocalCache import LocalCache
 
 default_min_chunk_size = 128 * 1024  # This is different from Remfile - this is an important decision because it determines the chunk size in the LocalCache
@@ -41,6 +42,7 @@ class LindiRemfile:
             Does not support using multiple threads
             Does not use memory cache if LocalCache is specified
             Handles DANDI authentication
+            Handles additional_url_resolver
 
         A note:
             In the context of LINDI, this LindiRemfile is going to be used for loading
@@ -367,6 +369,8 @@ def _resolve_dandi_url(url: str):
 
 
 def _resolve_url(url: str):
+    for aur in get_additional_url_resolvers():
+        url = aur(url)
     if url in _global_resolved_urls:
         elapsed = time.time() - _global_resolved_urls[url]["timestamp"]
         if elapsed < 60 * 10:

--- a/lindi/LindiRemfile/additional_url_resolvers.py
+++ b/lindi/LindiRemfile/additional_url_resolvers.py
@@ -1,0 +1,14 @@
+from typing import Callable, List
+
+
+_global = {
+    'additional_url_resolvers': []
+}
+
+
+def get_additional_url_resolvers() -> List[Callable[[str], str]]:
+    return _global['additional_url_resolvers']
+
+
+def add_additional_url_resolver(resolver: Callable[[str], str]):
+    _global['additional_url_resolvers'].append(resolver)

--- a/lindi/__init__.py
+++ b/lindi/__init__.py
@@ -3,3 +3,4 @@ from .LindiH5pyFile import LindiH5pyFile, LindiH5pyGroup, LindiH5pyDataset, Lind
 from .LindiStagingStore import LindiStagingStore, StagingArea  # noqa: F401
 from .LocalCache.LocalCache import LocalCache, ChunkTooLargeError  # noqa: F401
 from .File.File import File  # noqa: F401
+from .LindiRemfile.additional_url_resolvers import add_additional_url_resolver  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lindi"
-version = "0.4.0a1"
+version = "0.4.0a2"
 description = ""
 authors = [
     "Jeremy Magland <jmagland@flatironinstitute.org>",


### PR DESCRIPTION
Need to add arbitrary additional url resolvers for DANDI auth. It's a particularly special case for dendro because the DANDI API is not exposed to the job runner - so the resolution happens via an API request to dendro.