### PR TITLE
support zlib compression

### DIFF
--- a/lindi/LindiH5pyFile/writers/LindiH5pyGroupWriter.py
+++ b/lindi/LindiH5pyFile/writers/LindiH5pyGroupWriter.py
@@ -82,6 +82,14 @@ class LindiH5pyGroupWriter:
                 else:
                     raise Exception(f'Unexpected type for compression_opts: {type(compression_opts)}')
                 _zarr_compressor = numcodecs.GZip(level=level)
+            elif compression == 'zlib':
+                if compression_opts is None:
+                    level = 4
+                elif isinstance(compression_opts, int):
+                    level = compression_opts
+                else:
+                    raise Exception(f'Unexpected type for compression_opts: {type(compression_opts)}')
+                _zarr_compressor = numcodecs.Zlib(level=level)
             else:
                 raise Exception(f'Compression {compression} is not supported')
         elif compression is None:

--- a/lindi/conversion/h5_filters_to_codecs.py
+++ b/lindi/conversion/h5_filters_to_codecs.py
@@ -57,6 +57,8 @@ def h5_filters_to_codecs(h5obj: h5py.Dataset) -> Union[List[Codec], None]:
             filters.append(numcodecs.Zstd(level=properties[0]))
         elif str(filter_id) == "gzip":
             filters.append(numcodecs.Zlib(level=properties))
+        elif str(filter_id) == "zlib":
+            filters.append(numcodecs.Zlib(level=properties))
         elif str(filter_id) == "32004":
             raise RuntimeError(
                 f"{h5obj.name} uses lz4 compression - not supported"


### PR DESCRIPTION
This adds support for zlib compression when creating datasets, so you can do something like:

```
ds0 = g.create_dataset(
    f"spike_counts_ds_{ds_factor}",
    data=spike_counts_ds.astype(np.int32),
    chunks=(np.minimum(num_bins_per_chunk, num_ds_bins), num_units),
    compression='zlib'
)
```

This is important because zlib compression (unlike gzip and blosc) is deterministic (given the compression level). So then, if zlib compression is used, then two lindi.tar files that were created in the same way are going to be byte-equivalent. This is relevant for when I have a script that generates a file and stores in a content-addressable database (like kachery).