### PR TITLE
Update pyproject.toml to follow PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,33 @@
-[tool.poetry]
+[project]
 name = "lindi"
 version = "0.4.5"
 description = ""
 authors = [
-    "Jeremy Magland <jmagland@flatironinstitute.org>",
-    "Ryan Ly <rly@lbl.gov>",
-    "Oliver Ruebel <oruebel@lbl.gov>"
+    {name = "Jeremy Magland", email = "jmagland@flatironinstitute.org"},
+    {name = "Ryan Ly", email = "rly@lbl.gov"},
+    {name = "Oliver Ruebel", email = "oruebel@lbl.gov"}
 ]
 readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "zarr>=2.16.1",
+    "h5py>=3.10.0",
+    "requests>=2.31.0",
+    "tqdm>=4.66.4",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.8"
-numcodecs = ">=0.11.0" # relax version requirement for use with pyodide
-zarr = "^2.16.1"
-h5py = "^3.10.0"
-requests = "^2.31.0"
-tqdm = "^4.66.4"
+[dependency-groups]
+dev = [
+    "pynwb>=2.6.0",
+    "pytest>=7.4.4",
+    "pytest-cov>=4.1.0",
+    "ruff>=0.3.3",
+]
 
-[tool.poetry.group.dev.dependencies]
-pynwb = "^2.6.0"
-pytest = "^7.4.4"
-pytest-cov = "^4.1.0"
-ruff = "^0.3.3"
+[tool.poetry]
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.codespell]


### PR DESCRIPTION
PR updates the pyproject.toml file to be consistent with PEP 621. This means installation can be done using uv, which brings me joy.

Note: this is the format Poetry recommends using (https://python-poetry.org/docs/basic-usage/) and works with `Poetry>2.0`.