### PR TITLE
Constrain zarr dependency to <3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "zarr>=2.16.1",
+    "zarr>=2.16.1,<3",
     "h5py>=3.10.0",
     "requests>=2.31.0",
     "tqdm>=4.66.4",


### PR DESCRIPTION
## Summary
- Pin zarr to `>=2.16.1,<3` to prevent installation of zarr 3.x, which has breaking API changes

## Test plan
- [x] Existing tests continue to pass with zarr 2.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)